### PR TITLE
fix(sanchonet): update conway's genesis hash in cardano-node config file

### DIFF
--- a/config/sanchonet/config.json
+++ b/config/sanchonet/config.json
@@ -4,7 +4,7 @@
   "ByronGenesisFile": "byron-genesis.json",
   "ByronGenesisHash": "785eb88427e136378a15b0a152a8bfbeec7a611529ccda29c43a1e60ffb48eaa",
   "ConwayGenesisFile": "conway-genesis.json",
-  "ConwayGenesisHash": "f7d46bdd3b3c8caf38351c4eef3346a89241707270be0d6106e8a407db294cc6",
+  "ConwayGenesisHash": "89dd23dc6a020afa0c7521fe52fe14e38d494129933a3604154a3acfa4ac16e4",
   "EnableP2P": true,
   "ExperimentalHardForksEnabled": true,
   "ExperimentalProtocolsEnabled": true,


### PR DESCRIPTION
I've just came across this issue [0] while using `sanchonet` docker image. It seems the genesis file was updated but node's config wasn't, so here we go 🖖 

Thanks for maintaining this project 💌 

[0]
```
Conway related : Wrong genesis file: the actual hash is "89dd23dc6a020afa0c7521fe52fe14e38d494129933a3604154a3acfa4ac16e4", but the expected genesis hash given in the node configuration file is "f7d46bdd3b3c8caf38351c4eef3346a89241707270be0d6106e8a407db294cc6"
```