### PR TITLE
fix: sed only if writable

### DIFF
--- a/bin/run-network
+++ b/bin/run-network
@@ -44,10 +44,16 @@ if ! test -e /data/db/protocolMagicId; then
 fi
 
 # Enable TraceMempool and PeerSharing
-sed -i \
-	-e 's/"PeerSharing": false/"PeerSharing": true/' \
-	-e 's/"TraceMempool": false/"TraceMempool": true/' \
-	/opt/cardano/config/${NETWORK}/config.json
+set +e
+# Check if our configuration is writable (may be different from permissions)
+touch /opt/cardano/config/${NETWORK}/config.json 2>&1 >/dev/null
+if test $? -eq 0; then
+	sed -i \
+		-e 's/"PeerSharing": false/"PeerSharing": true/' \
+		-e 's/"TraceMempool": false/"TraceMempool": true/' \
+		/opt/cardano/config/${NETWORK}/config.json
+fi
+set -e
 
 echo "Starting: /usr/local/bin/cardano-node run"
 echo "--config /opt/cardano/config/${NETWORK}/config.json"

--- a/bin/run-node
+++ b/bin/run-node
@@ -76,10 +76,16 @@ if [[ ${CARDANO_BLOCK_PRODUCER} == true ]]; then
 	echo CARDANO_SHELLEY_VRF_KEY=${CARDANO_SHELLEY_VRF_KEY}
 	echo CARDANO_SHELLEY_OPERATIONAL_CERTIFICATE=${CARDANO_SHELLEY_OPERATIONAL_CERTIFICATE}
 else
-	sed -i \
-		-e 's/"PeerSharing": false/"PeerSharing": true/' \
-		-e 's/"TraceMempool": false/"TraceMempool": true/' \
-		${CARDANO_CONFIG}
+	set +e
+	# Check if our configuration is writable (may be different from permissions)
+	touch ${CARDANO_CONFIG} 2>&1 >/dev/null
+	if test $? -eq 0; then
+		sed -i \
+			-e 's/"PeerSharing": false/"PeerSharing": true/' \
+			-e 's/"TraceMempool": false/"TraceMempool": true/' \
+			${CARDANO_CONFIG}
+	fi
+	set -e
 fi
 
 echo AGGREGATOR_ENDPOINT=${AGGREGATOR_ENDPOINT}


### PR DESCRIPTION
If the configuration is mounted read-only, such as when used as a ConfigMap in Kubernetes, it can cause failure on startup. This should resolve that. Closes #156 