### PR TITLE
chore(cardano-configs): update docker image for cardano-node configs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN echo "Building tags/${NODE_VERSION}..." \
     && rm -rf /root/.cabal/store/ghc-${GHC_VERSION}
 
 FROM ghcr.io/blinklabs-io/cardano-cli:8.24.0.0 AS cardano-cli
-FROM ghcr.io/blinklabs-io/cardano-configs:20240515-2 as cardano-configs
+FROM ghcr.io/blinklabs-io/cardano-configs:main@sha256:6ea429fed70414038e760eca5be2d85f47c57a9cf4ac2bcd7629fdbabc1a6ad9 as cardano-configs
 FROM ghcr.io/blinklabs-io/mithril-client:0.9.2-1 AS mithril-client
 FROM ghcr.io/blinklabs-io/nview:0.10.0 AS nview
 FROM ghcr.io/blinklabs-io/txtop:0.10.0 AS txtop


### PR DESCRIPTION
Aloha team!

It seems that, although `cardano-configs` image was properly built with the latest config files for the node, latest docker images are not using them so node is crashing because of the lack of `plutusV3CostModel\` (at least for `sanchonet`, haven't tried other networks/configs yet).

I couldn't find a proper tag for `cardano-configs` image, so I'm raising this PR using the raw image id from [this github actions run](https://github.com/blinklabs-io/docker-cardano-configs/actions/runs/9749777356/job/26907708271) :)