### PR TITLE
fix: quiet error when CARDANO_DATABASE_PATH doesn't exist yet

### DIFF
--- a/bin/run-node
+++ b/bin/run-node
@@ -103,7 +103,7 @@ if ! test -e ${CARDANO_DATABASE_PATH}/protocolMagicId; then
 		cd $(dirname ${CARDANO_DATABASE_PATH})
 		export AGGREGATOR_ENDPOINT GENESIS_VERIFICATION_KEY SNAPSHOT_DIGEST
 		echo "Starting: /usr/local/bin/mithril-client cardano-db download ${SNAPSHOT_DIGEST}"
-		if [[ $(cd ${CARDANO_DATABASE_PATH}; pwd -P) != $(pwd -P)/db ]]; then
+		if [[ $(cd ${CARDANO_DATABASE_PATH} 2>/dev/null; pwd -P) != $(pwd -P)/db ]]; then
 			rm -rf db/*
 		fi
 		# Handle SIGTERM during initial sync


### PR DESCRIPTION
It's quite possible the path doesn't exist, yet. This fixes the display of an error when this happens.