### PR TITLE
feat: devnet support in run-node

### DIFF
--- a/bin/run-node
+++ b/bin/run-node
@@ -42,11 +42,31 @@ CARDANO_PORT=${CARDANO_PORT:-3001}
 CARDANO_RTS_OPTS=${CARDANO_RTS_OPTS:--N2 -A64m -I0 -qg -qb --disable-delayed-os-memory-return}
 CARDANO_SOCKET_PATH=${CARDANO_SOCKET_PATH:-/opt/cardano/ipc/socket}
 CARDANO_TOPOLOGY=${CARDANO_TOPOLOGY:-${CARDANO_CONFIG_BASE}/${CARDANO_NETWORK}/topology.json}
-# mithril
+# mithril and devnet
 case ${CARDANO_NETWORK} in
 	mainnet|preprod) __path=release-${CARDANO_NETWORK} ;;
 	preview) __path=pre-release-${CARDANO_NETWORK} ;;
 	sanchonet) __path=testing-${CARDANO_NETWORK} ;;
+	devnet)
+		# For devnet, we run as a block producer
+		CARDANO_BLOCK_PRODUCER=true
+		CARDANO_SHELLEY_KES_KEY=${CARDANO_CONFIG_BASE}/${CARDANO_NETWORK}/keys/kes.skey
+		CARDANO_SHELLEY_VRF_KEY=${CARDANO_CONFIG_BASE}/${CARDANO_NETWORK}/keys/vrf.skey
+		CARDANO_SHELLEY_OPERATIONAL_CERTIFICATE=${CARDANO_CONFIG_BASE}/${CARDANO_NETWORK}/keys/opcert.cert
+		RESTORE_SNAPSHOT=false
+		__path=testing-${CARDANO_NETWORK}
+		# clean up old data
+		rm -rf ${CARDANO_DATABASE_PATH}/*
+		# empty topology
+		echo '{"Producers": []}' > ${CARDANO_TOPOLOGY}
+		# network start times
+		sed -i "s/\"startTime\": [0-9]*/\"startTime\" $(date +%s)/" \
+			${CARDANO_CONFIG_BASE}/${CARDANO_NETWORK}/byron-genesis.json
+		sed -i "s/\"systemStart\": \".*\"/\"systemStart\": \"$(date -u +%FT%TZ)\"/" \
+			${CARDANO_CONFIG_BASE}/${CARDANO_NETWORK}/shelley-genesis.json
+		# update permissions on keys
+		find ${CARDANO_CONFIG_BASE}/${CARDANO_NETWORK}/keys/ -type f -name \*.skey | xargs chmod 0400
+		;;
 esac
 AGGREGATOR_ENDPOINT=${AGGREGATOR_ENDPOINT:-https://aggregator.${__path}.api.mithril.network/aggregator}
 GENESIS_VERIFICATION_KEY_PATH=${GENESIS_VERIFICATION_KEY_PATH:-${CARDANO_CONFIG_BASE}/${CARDANO_NETWORK}/genesis.vkey}


### PR DESCRIPTION
With the introduction of a `devnet` configuration into our cardano-configs image, we can now duplicate the Hydra demo's `prepare-devnet.sh` into our entrypoint to allow easily creating a new local network with a single block producer (this node) network.

Hydra: https://github.com/cardano-scaling/hydra