### PR TITLE
fix: bump(hotfix) mithril-client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN echo "Building tags/${NODE_VERSION}..." \
 
 FROM ghcr.io/blinklabs-io/cardano-cli:10.8.0.0-1 AS cardano-cli
 FROM ghcr.io/blinklabs-io/cardano-configs:20250213-1 AS cardano-configs
-FROM ghcr.io/blinklabs-io/mithril-client:0.12.0-1 AS mithril-client
+FROM ghcr.io/blinklabs-io/mithril-client:0.12.1-1 AS mithril-client
 FROM ghcr.io/blinklabs-io/mithril-signer:0.2.243-1 AS mithril-signer
 FROM ghcr.io/blinklabs-io/nview:0.10.8 AS nview
 FROM ghcr.io/blinklabs-io/txtop:0.12.3 AS txtop


### PR DESCRIPTION
ghcr.io/blinklabs-io/mithril-client:0.12.0-1 to ghcr.io/blinklabs-io/mithril-client:0.12.1-1