### PR TITLE
feat(mithril): inform user snapshot downloads may take a while

### DIFF
--- a/bin/run-network
+++ b/bin/run-network
@@ -34,6 +34,7 @@ if ! test -e /data/db/protocolMagicId; then
 		mkdir -p /data
 		cd /data
 		echo "Starting: /usr/local/bin/mithril-client cardano-db download ${SNAPSHOT_DIGEST} ${ANCILLARY_VERIFICATION_KEY:+--include-ancillary}"
+		echo "(This could take a while...)"
 		# Handle SIGTERM during initial sync
 		trap 'kill -TERM $(pidof mithril-client)' TERM
 		# Run mithril-client in the background so we can capture the PID and wait

--- a/bin/run-node
+++ b/bin/run-node
@@ -130,6 +130,7 @@ if ! test -e ${CARDANO_DATABASE_PATH}/protocolMagicId; then
 		cd $(dirname ${CARDANO_DATABASE_PATH})
 		export AGGREGATOR_ENDPOINT GENESIS_VERIFICATION_KEY ANCILLARY_VERIFICATION_KEY SNAPSHOT_DIGEST
 		echo "Starting: /usr/local/bin/mithril-client cardano-db download ${SNAPSHOT_DIGEST} ${ANCILLARY_VERIFICATION_KEY:+--include-ancillary}"
+		echo "(This could take a while...)"
 		if [[ $(cd ${CARDANO_DATABASE_PATH} 2>/dev/null; pwd -P) != $(pwd -P)/db ]]; then
 			rm -rf db/*
 		fi


### PR DESCRIPTION
The mithril-client, when executed in the background, does not give much user feedback so they may think the process is stuck when it is instead downloading tens of gigabytes of data. Adding a log message informs the user that a long delay is expected.