### PR TITLE
chore(configs): use 20251009 configs for Apex Fusion Prime networks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,12 +20,12 @@ RUN echo "Building tags/${NODE_VERSION}..." \
     && rm -rf /code/cardano-node/dist-newstyle/ \
     && rm -rf /root/.cabal/store/ghc-${GHC_VERSION}
 
-FROM ghcr.io/blinklabs-io/cardano-cli:10.4.0.0-1 AS cardano-cli
-FROM ghcr.io/blinklabs-io/cardano-configs:20250213-1 AS cardano-configs
+FROM ghcr.io/blinklabs-io/cardano-cli:9.4.1.0-1 AS cardano-cli
+FROM ghcr.io/blinklabs-io/cardano-configs:20251009-1 AS cardano-configs
 FROM ghcr.io/blinklabs-io/mithril-client:0.10.5-1 AS mithril-client
 FROM ghcr.io/blinklabs-io/mithril-signer:0.2.221-1 AS mithril-signer
-FROM ghcr.io/blinklabs-io/nview:0.10.5 AS nview
-FROM ghcr.io/blinklabs-io/txtop:0.12.2 AS txtop
+FROM ghcr.io/blinklabs-io/nview:0.11.0 AS nview
+FROM ghcr.io/blinklabs-io/txtop:0.13.1 AS txtop
 
 FROM debian:bookworm-slim AS cardano-node
 ENV LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"


### PR DESCRIPTION
This also downgrades the cardano-cli to pre-Conway.