### PR TITLE
feat: cardano-node 10.5.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/blinklabs-io/haskell:9.6.6-3.12.1.0-2 AS cardano-node-build
 # Install cardano-node
-ARG NODE_VERSION=10.5.1
+ARG NODE_VERSION=10.5.2
 ENV NODE_VERSION=${NODE_VERSION}
 RUN echo "Building tags/${NODE_VERSION}..." \
     && echo tags/${NODE_VERSION} > /CARDANO_BRANCH \


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update Docker build to cardano-node 10.5.2. This bumps NODE_VERSION in the Dockerfile so images use the latest patch release and upstream fixes.

<sup>Written for commit 54f6a267d4d8e18459fc77e011fd3b15a5c797f0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node.js runtime version to 10.5.2 for the build environment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->