### PR TITLE
feat: cardano-node 10.5.3

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -15,6 +15,7 @@ permissions:
 
 jobs:
   build-amd64:
+    # runs-on: ubuntu-latest
     runs-on: [self-hosted, Linux, X64, ansible]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0 https://github.com/actions/checkout/releases/tag/v5.0.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,7 @@ env:
 
 jobs:
   build-amd64:
+    # runs-on: ubuntu-latest
     runs-on: [self-hosted, Linux, X64, ansible]
     permissions:
       contents: read

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM ghcr.io/blinklabs-io/haskell:9.6.6-3.12.1.0-2 AS cardano-node-build
+FROM ghcr.io/blinklabs-io/haskell:9.6.6-3.12.1.0-3 AS cardano-node-build
 # Install cardano-node
-ARG NODE_VERSION=10.5.2
+ARG NODE_VERSION=10.5.3
 ENV NODE_VERSION=${NODE_VERSION}
 RUN echo "Building tags/${NODE_VERSION}..." \
     && echo tags/${NODE_VERSION} > /CARDANO_BRANCH \


### PR DESCRIPTION








<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update Dockerfile to build cardano-node 10.5.3 instead of 10.5.2, and bump the build base image to ghcr.io/blinklabs-io/haskell:9.6.6-3.12.1.0-3. Switch CI and publish workflows to self-hosted Linux X64 (ansible) runners for AMD64 builds.

<sup>Written for commit 09e06142c9b8177a413da2446ea8b647b2d903aa. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->









<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the build environment base image to a newer patch release and bumped the Node.js patch version to improve stability and compatibility during builds.
* **CI**
  * Switched CI job runners from the hosted default to self‑hosted Linux x86_64 runners to align build execution with on‑premise infrastructure and runner requirements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->