### PR TITLE
ci: change runners

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -2,8 +2,9 @@ name: Docker CI
 
 on:
   pull_request:
-    branches: ['main','release/**']
-    paths: ['Dockerfile','bin/**','config/**','.github/workflows/ci-docker.yml']
+    branches: ["main", "release/**"]
+    paths:
+      ["Dockerfile", "bin/**", "config/**", ".github/workflows/ci-docker.yml"]
 
 env:
   REGISTRY: ghcr.io
@@ -14,7 +15,7 @@ permissions:
 
 jobs:
   build-amd64:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, ansible]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0 https://github.com/actions/checkout/releases/tag/v5.0.0
       - name: qemu

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Conventional Commits
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, ansible]
     permissions:
       contents: read
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,8 +2,8 @@ name: publish
 
 on:
   push:
-    branches: ['main']
-    tags: ['v*.*.*']
+    branches: ["main"]
+    tags: ["v*.*.*"]
 
 concurrency: ${{ github.ref }}
 
@@ -12,9 +12,8 @@ env:
   GHCR_IMAGE_NAME: ghcr.io/blinklabs-io/cardano-node
 
 jobs:
-
   build-amd64:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, ansible]
     permissions:
       contents: read
       packages: write
@@ -148,7 +147,7 @@ jobs:
           done
 
   multi-arch-manifest:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, ansible]
     needs: [build-amd64, build-arm64]
     permissions:
       contents: read
@@ -287,12 +286,12 @@ jobs:
           short-description: "Cardano Node built from source on Debian"
 
   github-release:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, ansible]
     permissions:
       contents: write
     needs: [multi-arch-manifest]
     steps:
-      - run: "echo \"RELEASE_TAG=${GITHUB_REF#refs/tags/}\" >> $GITHUB_ENV"
+      - run: 'echo "RELEASE_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV'
       - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0 https://github.com/actions/github-script/releases/tag/v8.0.0
         if: startsWith(github.ref, 'refs/tags/')
         with:


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch CI and publish workflows to our self-hosted runner ([self-hosted, Linux, X64, ansible]) for consistent builds and releases. Also cleaned up YAML arrays/quotes and a small quoting issue.

- **Refactors**
  - Set runs-on to [self-hosted, Linux, X64, ansible] in ci-docker, conventional-commits, and publish (build-amd64, multi-arch-manifest, github-release).
  - Standardized array/quote formatting for branches/tags/paths and fixed a run command quote.

<sup>Written for commit b384d484e3adabf16c26a3de0c40c99c169d27bc. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized CI workflow YAML formatting and normalized branch/tag filter syntax.
  * Updated runner configuration for several pipeline jobs to use self-hosted Linux x64 (ansible) runners.
  * Minor environment variable formatting adjustment in release steps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->