### PR TITLE
chore: cardano-config 20251128

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN echo "Building tags/${NODE_VERSION}..." \
     && rm -rf /root/.cabal/store/ghc-${GHC_VERSION}
 
 FROM ghcr.io/blinklabs-io/cardano-cli:10.12.0.0-1 AS cardano-cli
-FROM ghcr.io/blinklabs-io/cardano-configs:20251014-1 AS cardano-configs
+FROM ghcr.io/blinklabs-io/cardano-configs:20251128-1 AS cardano-configs
 FROM ghcr.io/blinklabs-io/mithril-client:0.12.33-1 AS mithril-client
 FROM ghcr.io/blinklabs-io/mithril-signer:0.2.276-1 AS mithril-signer
 FROM ghcr.io/blinklabs-io/nview:0.12.0 AS nview


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bumped the cardano-configs base image to 20251128-1 to include the latest Cardano network configs and keep builds current.

<sup>Written for commit 13b2f50a2fc2f8cb813a04f00078dd8a78947a65. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

