### PR TITLE
fix(mithril): update script to match aggregator response

### DIFF
--- a/bin/run-network
+++ b/bin/run-network
@@ -30,7 +30,7 @@ if ! test -e /data/db/protocolMagicId; then
 		export GENESIS_VERIFICATION_KEY=$(</opt/cardano/config/${NETWORK}/genesis.vkey)
 		export ANCILLARY_VERIFICATION_KEY=$(</opt/cardano/config/${NETWORK}/ancillary.vkey)
 		export AGGREGATOR_ENDPOINT=https://aggregator.${__path}.api.mithril.network/aggregator
-		export SNAPSHOT_DIGEST=$(mithril-client cardano-db snapshot list --json | jq -r '.[0].digest')
+		export SNAPSHOT_DIGEST=$(mithril-client cardano-db snapshot list --json | jq -r '.[0].hash')
 		mkdir -p /data
 		cd /data
 		echo "Starting: /usr/local/bin/mithril-client cardano-db download ${SNAPSHOT_DIGEST} ${ANCILLARY_VERIFICATION_KEY:+--include-ancillary}"


### PR DESCRIPTION
It seems mithril aggregator api has changed its response and snapshot's digest is now under key .hash

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update run-network to read the snapshot digest from the .hash field in the Mithril aggregator response. Fixes snapshot download by aligning the jq filter with the new API.

<sup>Written for commit 74a21251afb9c0ada4d7a9670c1f86c09a68d1a9. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected snapshot parameter retrieval in the network initialization process to ensure proper download functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->