### PR TITLE
feat: cardano-node 10.5.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/blinklabs-io/haskell:9.6.6-3.12.1.0-3 AS cardano-node-build
 # Install cardano-node
-ARG NODE_VERSION=10.5.3
+ARG NODE_VERSION=10.5.4
 ENV NODE_VERSION=${NODE_VERSION}
 RUN echo "Building tags/${NODE_VERSION}..." \
     && echo tags/${NODE_VERSION} > /CARDANO_BRANCH \


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bump cardano-node to 10.5.4 in the Docker build to use the latest patch release. Ensures new images build against the updated tag.

<sup>Written for commit cc165f7b3977b192cf8cff333e869f58d013a436. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node runtime version to 10.5.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->