### PR TITLE
feat: cardano-node 10.6.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/blinklabs-io/haskell:9.6.6-3.12.1.0-3 AS cardano-node-build
 # Install cardano-node
-ARG NODE_VERSION=10.5.4
+ARG NODE_VERSION=10.6.2
 ENV NODE_VERSION=${NODE_VERSION}
 RUN echo "Building tags/${NODE_VERSION}..." \
     && echo tags/${NODE_VERSION} > /CARDANO_BRANCH \


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bumped cardano-node in the Dockerfile from 10.5.4 to 10.6.2 to build against the latest upstream tag and include recent fixes.

<sup>Written for commit 7cf377b2e6c6423d223f651922d68f0395a04e76. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

