### PR TITLE
feat: cardano-node 10.6.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM ghcr.io/blinklabs-io/haskell:9.6.6-3.12.1.0-3 AS cardano-node-build
+FROM ghcr.io/blinklabs-io/haskell:9.6.7-3.12.1.0-1 AS cardano-node-build
 # Install cardano-node
-ARG NODE_VERSION=10.5.4
+ARG NODE_VERSION=10.6.3
 ENV NODE_VERSION=${NODE_VERSION}
 RUN echo "Building tags/${NODE_VERSION}..." \
     && echo tags/${NODE_VERSION} > /CARDANO_BRANCH \
@@ -10,7 +10,6 @@ RUN echo "Building tags/${NODE_VERSION}..." \
     && git tag \
     && git checkout tags/${NODE_VERSION} \
     && echo "with-compiler: ghc-${GHC_VERSION}" >> cabal.project.local \
-    && echo "tests: False" >> cabal.project.local \
     && cabal update \
     && cabal build all \
     && mkdir -p /root/.local/bin/ \


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update Docker build to `cardano-node` 10.6.3 (from 10.5.4) and switch the Haskell base image to `ghcr.io/blinklabs-io/haskell:9.6.7-3.12.1.0-1`. Also stop force-disabling tests in `cabal.project.local` during the build.

<sup>Written for commit 8f8542c24a329d00f9acb13bcb5efa877177bdfc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

