### PR TITLE
chore(deps): cardano-cli 10.15.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN echo "Building tags/${NODE_VERSION}..." \
     && rm -rf /code/cardano-node/dist-newstyle/ \
     && rm -rf /root/.cabal/store/ghc-${GHC_VERSION}
 
-FROM ghcr.io/blinklabs-io/cardano-cli:10.14.0.0-1 AS cardano-cli
+FROM ghcr.io/blinklabs-io/cardano-cli:10.15.1.0-1 AS cardano-cli
 FROM ghcr.io/blinklabs-io/cardano-configs:20251128-1 AS cardano-configs
 FROM ghcr.io/blinklabs-io/mithril-client:0.12.38-1 AS mithril-client
 FROM ghcr.io/blinklabs-io/mithril-signer:0.3.7-1 AS mithril-signer


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update Dockerfile to use `ghcr.io/blinklabs-io/cardano-cli` 10.15.1.0-1, keeping our image aligned with the latest upstream release.

- **Dependencies**
  - `ghcr.io/blinklabs-io/cardano-cli`: 10.14.0.0-1 → 10.15.1.0-1

<sup>Written for commit 00a6373f7ec4ba5b4430469ce57b17d801560e5a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

