### PR TITLE
feat: cardano-node 10.7.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/blinklabs-io/haskell:9.6.7-3.12.1.0-1 AS cardano-node-build
 # Install cardano-node
-ARG NODE_VERSION=10.6.4
+ARG NODE_VERSION=10.7.1
 ENV NODE_VERSION=${NODE_VERSION}
 RUN echo "Building tags/${NODE_VERSION}..." \
     && echo tags/${NODE_VERSION} > /CARDANO_BRANCH \


### PR DESCRIPTION
Bumps `NODE_VERSION` to [cardano-node 10.7.1](https://github.com/IntersectMBO/cardano-node/releases/tag/10.7.1), released 2026-04-15.

Mirrors the pattern of #343 (10.6.4) and prior version-bump PRs: a single `ARG NODE_VERSION` change in the Dockerfile.

Upstream release notes: https://github.com/IntersectMBO/cardano-node/releases/tag/10.7.1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `cardano-node` to 10.7.1 by updating the `NODE_VERSION` build arg in the Dockerfile. Aligns our image with the 2026-04-15 upstream release.

<sup>Written for commit 5b804c8fbdb7a4da0390c798ca4566dea8609e37. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node version configuration in Docker build from 10.6.4 to 10.7.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->