### PR TITLE
fix: Add liburing2 to Dockerfile dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,7 @@ RUN apt-get update -y && \
     libsystemd0 \
     libssl3 \
     libtinfo6 \
+    liburing2 \
     llvm-14-runtime \
     lsof \
     netbase \


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add `liburing2` to the Docker image to provide io_uring runtime support. This prevents container start-up errors due to missing `liburing.so.2` on Debian/Ubuntu bases.

<sup>Written for commit 8cc1e91bfce0f51d8ff457c9a884ed0896809adc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Dockerfile to include liburing2 in the base Debian layer dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->