### PR TITLE
feat: cardano-node 11.0.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/blinklabs-io/haskell:9.6.7-3.12.1.0-3 AS cardano-node-build
 # Install cardano-node
-ARG NODE_VERSION=10.7.1
+ARG NODE_VERSION=11.0.1
 ENV NODE_VERSION=${NODE_VERSION}
 RUN echo "Building tags/${NODE_VERSION}..." \
     && echo tags/${NODE_VERSION} > /CARDANO_BRANCH \


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update Dockerfile to build `cardano-node` 11.0.1 instead of 10.7.1. This keeps our image aligned with the latest upstream release.

<sup>Written for commit 36ee7cd69bb425131a116006f5b9db2d500edc8d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Cardano node version from 10.7.1 to 11.0.1 in the build environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->