### PR TITLE
chore: cardano-cli 11.0.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN echo "Building tags/${NODE_VERSION}..." \
     && rm -rf /code/cardano-node/dist-newstyle/ \
     && rm -rf /root/.cabal/store/ghc-${GHC_VERSION}
 
-FROM ghcr.io/blinklabs-io/cardano-cli:10.15.1.0-1 AS cardano-cli
+FROM ghcr.io/blinklabs-io/cardano-cli:11.0.0.0-1 AS cardano-cli
 FROM ghcr.io/blinklabs-io/cardano-configs:20260430-1 AS cardano-configs
 FROM ghcr.io/blinklabs-io/mithril-client:0.13.9-1 AS mithril-client
 FROM ghcr.io/blinklabs-io/mithril-signer:1.0.0-1 AS mithril-signer


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the Dockerfile to use `ghcr.io/blinklabs-io/cardano-cli` 11.0.0.0-1, keeping our image aligned with the latest Cardano CLI.

- **Dependencies**
  - Bumped `ghcr.io/blinklabs-io/cardano-cli` from 10.15.1.0-1 to 11.0.0.0-1.

<sup>Written for commit ba4529a4c5091676e8e1122077421da550b67c68. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

